### PR TITLE
fix warnings caused by invalid leveloffset and cross references

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem 'rake', '12.0.0'
 gem 'asciidoctor-pdf', '1.5.0.alpha.15'
 # NOTE switch to asciidoctor-epub3 1.5.0.alpha.7 once released
-gem 'asciidoctor-epub3', github: 'mojavelinux/asciidoctor-epub3', branch: 'integration'
+gem 'asciidoctor-epub3', github: 'asciidoctor/asciidoctor-epub3'
 # NOTE refer to https://github.com/packetmonkey/prawn-gmagick#amazon-ec2--elastic-beanstalk-installation for prerequisites
 gem 'prawn-gmagick', '0.0.8'
 gem 'pygments.rb', '1.1.1'

--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@
 #   bundle config --local build.nokogiri --use-system-libraries
 #   bundle --path=.bundle/gems
 #
-# NOTE: The gems are installed under the path .bundle/gems.
+# NOTE The gems are installed under the path .bundle/gems.
 #
 # Finally, run a named task using the `bundle exec rake` command:
 #
@@ -46,7 +46,7 @@ end
 
 # TIP invoke using epub[ebook-validate] to validate
 desc 'Build the EPUB3 format'
-task :epub, [:attrs] do |task, args|
+task :epub, [:attrs] do |_, args|
   require 'asciidoctor-epub3'
   Asciidoctor.convert_file MASTER_FILENAME,
     safe: :unsafe,
@@ -62,7 +62,7 @@ task :mobi do
   Asciidoctor.convert_file MASTER_FILENAME,
     safe: :unsafe,
     backend: 'epub3',
-    attributes: 'epub3-stylesdir=styles/epub3 ebook-format=kf8',
+    attributes: 'epub3-stylesdir=styles/epub3 ebook-format=kf8 ebook-compress=huffdic',
     to_dir: BUILD_DIR,
     mkdirs: true
   File.unlink %(#{BUILD_DIR}/#{File.basename MASTER_FILENAME, '.*'}-kf8.epub)

--- a/first-steps-with-rails.adoc
+++ b/first-steps-with-rails.adoc
@@ -371,7 +371,7 @@ Rails.application.routes.draw do
 end
 ----
 
-Alter on we are going to dive more into xref:routes#routes[Routes].
+Alter on we are going to dive more into xref:routing#routing[Routes].
 
 IMPORTANT: A static file in the directory `public` always has higher
            priority than a route in the `config/routes.rb`! So if we
@@ -522,7 +522,7 @@ Now you understand how Ruby code is used in the view.
 [qanda]
 I don't understand anything. I can't cope with the Ruby code. Could you please explain it again?::
   Is it possible that you have not completely worked your way through
-  xref:routes#routes[Ruby Basics]? Please do take
+  xref:ruby-basics#ruby-basics[Ruby Basics]? Please do take
   your time with it and have another thorough look. Otherwise, the rest
   won't make any sense here.
 I can understand the Ruby code and the HTML output. But I don't get why some HTML code was rendered around it if I didn't even write that HTML code. Where does it come from, and can I influence it?::
@@ -1159,7 +1159,7 @@ You will find all the views in the directory `app/views/.`
 === Controller
 
 Once a web page call has ended up in a route (see
-xref:routes#routes[chapter "Routes"]), it goes from there to
+xref:routing#routing[chapter "Routes"]), it goes from there to
 the controller. The route specifies a certain method (action) as target.
 This method can then fulfil the desired tasks (such as finding a
 specific set of data and saving it in an instance variable) and then

--- a/learn-rails-51-part-I.adoc
+++ b/learn-rails-51-part-I.adoc
@@ -12,10 +12,10 @@ v5.1.0, 2016-04-08
 :toc:
 :toclevels: 2
 :source-highlighter: pygments
+ifndef::ebook-format[:leveloffset: +1]
 
 include::preface1.adoc[]
 
-:leveloffset: +1
 include::how-to.adoc[]
 
 include::ruby-basics.adoc[]

--- a/learn-rails-51-part-II.adoc
+++ b/learn-rails-51-part-II.adoc
@@ -12,10 +12,10 @@ v5.1.0, 2016-03-27
 :toc:
 :toclevels: 2
 :source-highlighter: pygments
+ifndef::ebook-format[:leveloffset: +1]
 
 include::preface2.adoc[]
 
-:leveloffset: +1
 include::how-to.adoc[]
 
 include::test-driven-development.adoc[]

--- a/routing.adoc
+++ b/routing.adoc
@@ -499,7 +499,7 @@ edit_post GET    /posts/:id/edit(.:format) posts#edit
 ----
 
 You have already encountered these RESTful routes in the chapter
-xref:first-steps-with-rail#creating-html-dynamically-with-erb["Scaffolding and
+xref:first-steps-with-rails#creating-html-dynamically-with-erb["Scaffolding and
 REST"]. They are required for displaying and editing records.
 
 [[selecting-specific-routes-with-only-or-except]]

--- a/scaffolding-and-rest.adoc
+++ b/scaffolding-and-rest.adoc
@@ -392,7 +392,7 @@ $ rails db:seed
 === The Routes
 
 `rails generate scaffold` has created a route (more on this later in
-the chapter xref:routes#routes["Routes"]), a controller and several views for us.
+the chapter xref:routing#routing["Routes"]), a controller and several views for us.
 
 We could also have done all of this manually. Scaffolding is merely an
 automatism that does the work for us for some basic things. This is


### PR DESCRIPTION
- don't bump leveloffset when building e-book
- fix cross references in Part I
- switch to asciidoctor-epub3 master
- fix warning in Rake build
- enable compression in kindlegen